### PR TITLE
Fix add_r20_to_nibbles loop bounds

### DIFF
--- a/components/elero/elero.cpp
+++ b/components/elero/elero.cpp
@@ -303,7 +303,7 @@ void Elero::add_r20_to_nibbles(uint8_t* msg, uint8_t r20, uint8_t start, uint8_t
 {
   uint8_t i;
 
-  for( i = 0; i < 8; i++ )
+  for(i = start; i < length; i++)
   {
     uint8_t d = msg[i];
 


### PR DESCRIPTION
## Summary
- only modify message bytes from `start` up to `length`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684135a5171c832296fd52bd94f08d9d