### PR TITLE
Fix compatibility with ESPHome 2025.4

### DIFF
--- a/components/elero/cover/__init__.py
+++ b/components/elero/cover/__init__.py
@@ -30,33 +30,35 @@ def poll_interval(value):
         return 4294967295  # uint32_t max
     return cv.positive_time_period_milliseconds(value)
 
-CONFIG_SCHEMA = cover.cover_schema(EleroCover).extend(
+CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
     {
+        cv.GenerateID(): cv.declare_id(EleroCover),
         cv.GenerateID(CONF_ELERO_ID): cv.use_id(elero),
-        cv.Required(CONF_BLIND_ADDRESS): cv.hex_int_range(min=0x0, max=0xffffff),
+        cv.Required(CONF_BLIND_ADDRESS): cv.hex_int_range(min=0x0, max=0xFFFFFF),
         cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=255),
-        cv.Required(CONF_REMOTE_ADDRESS): cv.hex_int_range(min=0x0, max=0xffffff),
+        cv.Required(CONF_REMOTE_ADDRESS): cv.hex_int_range(min=0x0, max=0xFFFFFF),
         cv.Optional(CONF_POLL_INTERVAL, default="5min"): poll_interval,
         cv.Optional(CONF_OPEN_DURATION, default="0s"): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_CLOSE_DURATION, default="0s"): cv.positive_time_period_milliseconds,
-        cv.Optional(CONF_PAYLOAD_1, default=0x00): cv.hex_int_range(min=0x0, max=0xff),
-        cv.Optional(CONF_PAYLOAD_2, default=0x04): cv.hex_int_range(min=0x0, max=0xff),
-        cv.Optional(CONF_PCKINF_1, default=0x6a): cv.hex_int_range(min=0x0, max=0xff),
-        cv.Optional(CONF_PCKINF_2, default=0x00): cv.hex_int_range(min=0x0, max=0xff),
-        cv.Optional(CONF_HOP, default=0x0a): cv.hex_int_range(min=0x0, max=0xff),
-        cv.Optional(CONF_COMMAND_UP, default=0x20): cv.hex_int_range(min=0x0, max=0xff),
-        cv.Optional(CONF_COMMAND_DOWN, default=0x40): cv.hex_int_range(min=0x0, max=0xff),
-        cv.Optional(CONF_COMMAND_STOP, default=0x10): cv.hex_int_range(min=0x0, max=0xff),
-        cv.Optional(CONF_COMMAND_CHECK, default=0x00): cv.hex_int_range(min=0x0, max=0xff),
-        cv.Optional(CONF_COMMAND_TILT, default=0x24): cv.hex_int_range(min=0x0, max=0xff),
+        cv.Optional(CONF_PAYLOAD_1, default=0x00): cv.hex_int_range(min=0x0, max=0xFF),
+        cv.Optional(CONF_PAYLOAD_2, default=0x04): cv.hex_int_range(min=0x0, max=0xFF),
+        cv.Optional(CONF_PCKINF_1, default=0x6A): cv.hex_int_range(min=0x0, max=0xFF),
+        cv.Optional(CONF_PCKINF_2, default=0x00): cv.hex_int_range(min=0x0, max=0xFF),
+        cv.Optional(CONF_HOP, default=0x0A): cv.hex_int_range(min=0x0, max=0xFF),
+        cv.Optional(CONF_COMMAND_UP, default=0x20): cv.hex_int_range(min=0x0, max=0xFF),
+        cv.Optional(CONF_COMMAND_DOWN, default=0x40): cv.hex_int_range(min=0x0, max=0xFF),
+        cv.Optional(CONF_COMMAND_STOP, default=0x10): cv.hex_int_range(min=0x0, max=0xFF),
+        cv.Optional(CONF_COMMAND_CHECK, default=0x00): cv.hex_int_range(min=0x0, max=0xFF),
+        cv.Optional(CONF_COMMAND_TILT, default=0x24): cv.hex_int_range(min=0x0, max=0xFF),
         cv.Optional(CONF_SUPPORTS_TILT, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
 
 async def to_code(config):
-    var = await cover.new_cover(config)
+    var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+    await cover.register_cover(var, config)
 
     parent = await cg.get_variable(config[CONF_ELERO_ID])
     cg.add(var.set_elero_parent(parent))


### PR DESCRIPTION
## Summary
- update the cover component to work with ESPHome 2025.4 and later

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68435d2241088322ae5aa8f95df8403a